### PR TITLE
Use all arguments for conversion

### DIFF
--- a/nginx2goaccess.sh
+++ b/nginx2goaccess.sh
@@ -54,7 +54,7 @@
 # Author: Rogério Carvalho Schneider <stockrt@gmail.com>
 
 # Params
-log_format="$1"
+log_format="${@:1}"
 
 # Usage
 if [[ -z "$log_format" ]]; then


### PR DESCRIPTION
Helps to convert multiline directive, e.g.

```
nginx2goaccess '$remote_addr - $remote_user [$time_local] "$request" ' \
                          '$status $body_bytes_sent "$http_referer" ' \
                          '"$http_user_agent" "$http_x_forwarded_for" ' \
                          '"$host" sn="$server_name" ' \
                          'rt=$request_time ' \
                          'ua="$upstream_addr" us="$upstream_status" ' \
                          'ut="$upstream_response_time" ul="$upstream_response_length" ' \
                          'cs=$upstream_cache_status' 
```